### PR TITLE
Fix neighbour and drawing bugs

### DIFF
--- a/Island.js
+++ b/Island.js
@@ -1,6 +1,7 @@
 import {
     changeHex,
-    configureNeigboursForIslands
+    configureNeigboursForIslands,
+    redrawMap
 } from './helperFunctions.js';
 import { Dice } from './Dice.js';
 
@@ -35,7 +36,6 @@ export class Island {
                 return;
             }
         }
-        this.drawDices();
     }
 
     drawDices() {
@@ -356,35 +356,25 @@ export class Island {
         }
 
         // Handling attacking
-        if (selectedIsland !== null && this.mouseInBounds && this.neighbourIslands.some(island => island === selectedIsland)) {
-            // Defending island won
-            if (this.throwDice()) {
-                for (let i = selectedIsland.head; i !== null; i = i.next){
-                    i.drawFill();
-                    i.drawOutlines();
-                }
+        if (selectedIsland !== null && 
+            selectedIsland.team !== this.team && 
+            this.mouseInBounds && 
+            this.neighbourIslands.some(island => island === selectedIsland)) {
+            if (!this.throwDice()) {
                 // The attacker island won
-            } else {
                 this.dices = selectedIsland.dices;
+                this.removeDice();
                 this.team = selectedIsland.team;
                 this.teamColour = selectedIsland.teamColour;
-                for (let i = this.head; i !== null; i = i.next){
-                    i.drawFill();
-                    i.drawOutlines();
-                }
-                this.drawDices();
                 this.neighbourIslands.splice(this.neighbourIslands.indexOf(selectedIsland));
                 selectedIsland.neighbourIslands.splice(selectedIsland.neighbourIslands.indexOf(this));
                 configureNeigboursForIslands(polygonArr);
-            }
-            for (let i = selectedIsland.head; i !== null; i = i.next){
-                i.drawFill();
-                i.drawOutlines();
             }
             selectedIsland.selected = false;
             selectedIsland.resetDices();
             selectedIsland.drawDices();
             selectedIsland = null;
+            redrawMap();
         }
     }
 
@@ -448,5 +438,11 @@ export class Island {
     resetDices() {
         this.dices = [];
         this.dices.push(new Dice());
+    }
+
+    removeDice() {
+        if (this.dices.length > 1){
+            this.dices.splice(this.dices.length - 1);
+        }
     }
 }

--- a/Polygon.js
+++ b/Polygon.js
@@ -2,8 +2,7 @@ const canvas = document.getElementById('myCanvas');
 const ctx = canvas.getContext('2d');
 
 export class Polygon{
-    constructor(id, x, y, r) {
-        this.id = id;
+    constructor(x, y, r) {
         this.x = x;
         this.y = y;
         this.r = r;

--- a/globalVariables.js
+++ b/globalVariables.js
@@ -9,6 +9,7 @@ window.teamColours = [];
 window.polygonArr = [];
 window.offset = 10;
 window.neighbourConstant = (gridSize * 2 - (gridSize / 2.025));
+window.map = [];
 window.chunkMap = new Map();
 window.chunkSize = 100; 
 window.highlightedPolygons = [];

--- a/helperFunctions.js
+++ b/helperFunctions.js
@@ -58,7 +58,6 @@ export function generateMap(polygonArr) {
     let currentY = 0; // Current y position where a new poly is created
     let allIslands = []; // All islands in the map
     let currentIsland;
-    let currentId = 1;
 
     // If islandCount = 3, then each team will have 3 islands each.
     for (let island = 0; island < islandCount; island++){
@@ -69,14 +68,12 @@ export function generateMap(polygonArr) {
             for (let i = 0; i < islandSize; i++) {
                 if (polygonArr[currentY][currentX] === 0){
                     let newPolygon = new Polygon(
-                        currentId,
                         currentX * neighbourConstant + gridSize + offset, 
                         currentY * gridSize * 2 + gridSize + (currentX % 2 > 0 ? gridSize : 0) + offset,
                         gridSize
                     );
                     currentIsland.push(newPolygon);
                     polygonArr[currentY][currentX] = newPolygon;
-                    currentId += 1;
                 }
                 const xDirection = Math.floor(Math.random() * 3) - 1;
                 const yDirection = xDirection === 0 ? (Math.random() < 0.5 ? -1 : 1) : 0;
@@ -129,14 +126,13 @@ export function configureNeigboursForIslands(polygonArr) {
                                 ((posY >= 0 && posY < polygonArr.length))) {
                                 // Check if the neighbour is not an empty place
                                 if (polygonArr[posY][posX] !== 0) {
-                                    // Check if the neighbours team doesn't match
-                                    if (polygonArr[y][x].island.team !== polygonArr[posY][posX].island.team) {
-                                        if (!polygonArr[y][x].island.neighbourIslands.some(island => island === polygonArr[posY][posX])) {
-                                            polygonArr[y][x].island.neighbourIslands.push(polygonArr[posY][posX].island);
-                                        }
-                                        if (!polygonArr[posY][posX].island.neighbourIslands.some(island => island === polygonArr[y][x])) {
-                                            polygonArr[posY][posX].island.neighbourIslands.push(polygonArr[y][x].island);
-                                        }
+                                    if (!polygonArr[y][x].island.neighbourIslands.some(island => island === polygonArr[posY][posX].island)) {
+                                        polygonArr[y][x].island.neighbourIslands.push(polygonArr[posY][posX].island);
+                                        continue;
+                                    }
+                                    if (!polygonArr[posY][posX].island.neighbourIslands.some(island => island === polygonArr[y][x].island)) {
+                                        polygonArr[posY][posX].island.neighbourIslands.push(polygonArr[y][x].island);
+                                        continue;
                                     }
                                 }
                             }
@@ -161,14 +157,11 @@ export function configureNeigboursForIslands(polygonArr) {
                                 ((posY >= 0 && posY < polygonArr.length))) {
                                 // Check if the neighbour is not an empty place
                                 if (polygonArr[posY][posX] !== 0) {
-                                    // Check if the neighbours team doesn't match
-                                    if (polygonArr[y][x].island.team !== polygonArr[posY][posX].island.team) {
-                                        if (!polygonArr[y][x].island.neighbourIslands.some(island => island === polygonArr[posY][posX])) {
-                                            polygonArr[y][x].island.neighbourIslands.push(polygonArr[posY][posX].island);
-                                        }
-                                        if (!polygonArr[posY][posX].island.neighbourIslands.some(island => island === polygonArr[y][x])) {
-                                            polygonArr[posY][posX].island.neighbourIslands.push(polygonArr[y][x].island);
-                                        }
+                                    if (!polygonArr[y][x].island.neighbourIslands.some(island => island === polygonArr[posY][posX].island)) {
+                                        polygonArr[y][x].island.neighbourIslands.push(polygonArr[posY][posX].island);
+                                    }
+                                    if (!polygonArr[posY][posX].island.neighbourIslands.some(island => island === polygonArr[y][x].island)) {
+                                        polygonArr[posY][posX].island.neighbourIslands.push(polygonArr[y][x].island);
                                     }
                                 }
                             }
@@ -210,4 +203,32 @@ export function changeHex(color, amount = 20) {
     const toHex = (c) => c.toString(16).padStart(2, '0');
 
     return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+export function redrawMap() {
+    for (let i = 0; i < canvas.width; i += chunkSize){
+        for (let j = 0; j < canvas.height; j += chunkSize){
+            drawSquare(i + chunkSize / 2, j + chunkSize / 2, chunkSize, 2, 'white', 'gray');
+        }
+    }
+    for (let i = 0; i < map.length; i++){
+        if (map[i] !== undefined){
+            map[i].draw();
+            map[i].drawOutlines();
+        }
+    }
+
+    for (let i = 0; i < map.length; i++){
+        if (map[i] !== undefined){
+            map[i].drawDices();
+        }
+    }
+}
+
+export function configureAllNeighbours() {
+    for (let i = 0; i < map.length; i++){
+        if (map[i] !== undefined){
+            map[i].configureNeigbours();
+        }
+    }
 }

--- a/script.js
+++ b/script.js
@@ -1,9 +1,9 @@
 const canvas = document.getElementById('myCanvas');
-import { generateMap, 
-    drawChunkSquare, 
+import { generateMap,
     getRandomHexColor,
     configureNeigboursForIslands,
-    drawDot
+    configureAllNeighbours,
+    redrawMap
 } from './helperFunctions.js';
 import { Chunk } from './Chunk.js';
 
@@ -25,25 +25,12 @@ for (let i = 0; i < teamCount; i++) {
     teamColours.push(getRandomHexColor(i));
 }
 
+
 // Generate empty polygon array
-const map = generateMap(polygonArr);
+map = generateMap(polygonArr);
+configureAllNeighbours();
+redrawMap();
 configureNeigboursForIslands(polygonArr);
-
-// Draw chunk grid
-for (let i = 0; i < canvas.width; i += chunkSize){
-    for (let j = 0; j < canvas.height; j += chunkSize){
-        drawChunkSquare(i, j);
-    }
-}
-
-
-for (let i = 0; i < map.length; i++){
-    if (map[i] !== undefined){
-        map[i].draw();
-        map[i].configureNeigbours();
-        map[i].drawOutlines();
-    }
-}
 
 let lastChunkKey = `${chunkSize/2}:${chunkSize/2}`;
 canvas.addEventListener('mousemove', (event) => {


### PR DESCRIPTION
Fixed:
> Neighbour configuration bug. Now neighbours are set correctly both from the start and after attacking
> Redrawing was fixed a bit. After attacking another island some unnecessary dices are no longer visible on the map.
Though redrawing still needs to be improved, because some dices are drawn below other islands, even if the mouse is hovering over that island